### PR TITLE
Allow optionally specifying Series Instance UID

### DIFF
--- a/dcmrtstruct2nii/adapters/input/image/dcminputadapter.py
+++ b/dcmrtstruct2nii/adapters/input/image/dcminputadapter.py
@@ -6,15 +6,18 @@ from dcmrtstruct2nii.exceptions import InvalidFileFormatException
 
 
 class DcmInputAdapter(AbstractInputAdapter):
-    def ingest(self, input_dir):
+    def ingest(self, input_dir, series_id=None):
         '''
             Load DICOMs from input_dir to a single 3D image and make sure axial
             direction is on third axis.
             :param input_dir: Input directory where the dicom files are located
+            :param series_id: Optional, the Series Instance UID for the image dicoms
             :return: multidimensional array with pixel data, metadata
         '''
         dicom_reader = sitk.ImageSeriesReader()
-        dicom_file_names = dicom_reader.GetGDCMSeriesFileNames(str(input_dir))
+        if series_id is None:
+            series_id = ''
+        dicom_file_names = dicom_reader.GetGDCMSeriesFileNames(str(input_dir), seriesID=series_id)
 
         if not dicom_file_names:
             raise InvalidFileFormatException('Directory {} is not a dicom'.format(input_dir))

--- a/dcmrtstruct2nii/cli/convert.py
+++ b/dcmrtstruct2nii/cli/convert.py
@@ -15,6 +15,7 @@ class Convert(PatchedCommand):
         {--o|output= : Output path, example: /tmp/output}
         {--g|gzip=?true : Optional, gzip output .nii}
         {--s|structures=? : Optional, list of structures that need to be converted, example: Patient, Spinal, Dose-1}
+        {--i|series-id=? : Optional, the Series ID of the image DICOMs. Use to exclude other series in the same directory}
         {--f|mask-foreground-color=?255 : Optional, the foreground color used for the mask. Must be between 0-255.}
         {--b|mask-background-color=?0 : Optional, the background color used for the mask. Must be between 0-255.}
         {--c|convert-original-dicom=?true : Optional, convert the original dicom to nii}
@@ -33,6 +34,8 @@ class Convert(PatchedCommand):
 
         convert_original_dicom = self._castToBool(self.option('convert-original-dicom'))
 
+        series_id = self.option('series-id')
+
         if structures:
             structures = [x.strip() for x in structures.split(',')]
 
@@ -41,6 +44,6 @@ class Convert(PatchedCommand):
             return -1
 
         try:
-            dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures, gzip, mask_background, mask_foreground, convert_original_dicom)
+            dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures, gzip, mask_background, mask_foreground, convert_original_dicom, series_id)
         except (InvalidFileFormatException, PathDoesNotExistException, UnsupportedTypeException, ValueError,) as e:
             logging.error(str(e))

--- a/dcmrtstruct2nii/facade/dcmrtstruct2nii.py
+++ b/dcmrtstruct2nii/facade/dcmrtstruct2nii.py
@@ -26,7 +26,7 @@ def list_rt_structs(rtstruct_file):
     return [struct['name'] for struct in rtstructs]
 
 
-def dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures=None, gzip=True, mask_background_value=0, mask_foreground_value=255, convert_original_dicom=True):  # noqa: C901 E501
+def dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures=None, gzip=True, mask_background_value=0, mask_foreground_value=255, convert_original_dicom=True, series_id=None):  # noqa: C901 E501
     """
     Converts A DICOM and DICOM RT Struct file to nii
 
@@ -35,6 +35,8 @@ def dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures=None, gzi
     :param output_path: Output path where the masks are written to
     :param structures: Optional, list of structures to convert
     :param gzip: Optional, output .nii.gz if set to True, default: True
+    :param series_id: Optional, the Series Instance UID. Use  to specify the ID corresponding to the image if there are
+    dicoms from more than one series in `dicom_file` folder
 
     :raise InvalidFileFormatException: Raised when an invalid file format is given.
     :raise PathDoesNotExistException: Raised when the given path does not exist.
@@ -64,7 +66,7 @@ def dcmrtstruct2nii(rtstruct_file, dicom_file, output_path, structures=None, gzi
     rtreader = RtStructInputAdapter()
 
     rtstructs = rtreader.ingest(rtstruct_file)
-    dicom_image = DcmInputAdapter().ingest(dicom_file)
+    dicom_image = DcmInputAdapter().ingest(dicom_file, series_id=series_id)
 
     dcm_patient_coords_to_mask = DcmPatientCoords2Mask()
     nii_output_adapter = NiiOutputAdapter()


### PR DESCRIPTION
Hi @Sikerdebaard! I found that when there are dicoms with two different Series Instance UID values, non-image dicoms would sometimes be loaded and treated as images. For instance, in one dataset I'm using the RD*.dcm has a different ID than the CT*.dcm (although they do correspond in reality), and the dose structure was getting loaded as the image. Then the program would of course crash when trying to export the structures as it couldn't map them to the (non-)image. This allows the series ID to optionally be specified so that the correct images will be loaded.

Specifically:
- [This](https://github.com/Sikerdebaard/dcmrtstruct2nii/blob/b240d99da1feffaee32d88da98b1ab63ad79de4c/dcmrtstruct2nii/adapters/input/image/dcminputadapter.py#L17) might load a non-image DICOM due to `GetGDCMSeriesFileNames` from SimpleITK returning only the files associated with the [first series ID it discovers](https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1ImageSeriesReader.html#a148badf23595d59e34b1d9360c79b539)  by default
- Then we would get an error [here](https://github.com/Sikerdebaard/dcmrtstruct2nii/blob/b240d99da1feffaee32d88da98b1ab63ad79de4c/dcmrtstruct2nii/adapters/convert/rtstructcontour2mask.py#L39)

Depending on whether you were using the CLI or the Python interface, the error messages looked like this:

CLI:
```
Working on mask RANDOM

  RuntimeError

  Exception thrown in SimpleITK Image_TransformPhysicalPointToIndex: d:\bld\libsimpleitk_1627514864077\work\code\common\src\sitkPimpleImageBase.hxx:201:
  sitk::ERROR: vector dimension mismatch

  at ~\Miniconda3\envs\tf2.3\lib\site-packages\SimpleITK\SimpleITK.py:3242 in TransformPhysicalPointToIndex
       3238│         Transform physical point to index
       3239│
       3240│
       3241│         """
    →  3242│         return _SimpleITK.Image_TransformPhysicalPointToIndex(self, point)
       3243│
       3244│     def TransformPhysicalPointToContinuousIndex(self, point):
       3245│
       3246│         TransformPhysicalPointToContinuousIndex(Image self, VectorDouble point) -> VectorDouble
```

Python:
```
Traceback (most recent call last):
  File "dcmrtstruct2nii\dcmrtstruct2nii\adapters\convert\rtstructcontour2mask.py", line 40, in convert
    world_coords = dicom_image.TransformPhysicalPointToContinuousIndex((coordinates['x'][index], coordinates['y'][index], coordinates['z'][index]))
  File "Miniconda3\envs\tf2.3\lib\site-packages\SimpleITK\SimpleITK.py", line 3253, in TransformPhysicalPointToContinuousIndex
    return _SimpleITK.Image_TransformPhysicalPointToContinuousIndex(self, point)
RuntimeError: Exception thrown in SimpleITK Image_TransformPhysicalPointToContinuousIndex: d:\bld\libsimpleitk_1627514864077\work\code\common\src\sitkPimpleImageBase.hxx:237:
sitk::ERROR: vector dimension mismatch

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dcmrtstruct2nii\dcmrtstruct2nii\facade\dcmrtstruct2nii.py", line 81, in dcmrtstruct2nii
    mask = dcm_patient_coords_to_mask.convert(rtstruct['sequence'], dicom_image, mask_background_value, mask_foreground_value)
  File "dcmrtstruct2nii\dcmrtstruct2nii\adapters\convert\rtstructcontour2mask.py", line 42, in convert
    world_coords = dicom_image.TransformPhysicalPointToIndex(
  File "Miniconda3\envs\tf2.3\lib\site-packages\SimpleITK\SimpleITK.py", line 3242, in TransformPhysicalPointToIndex
    return _SimpleITK.Image_TransformPhysicalPointToIndex(self, point)
RuntimeError: Exception thrown in SimpleITK Image_TransformPhysicalPointToIndex: d:\bld\libsimpleitk_1627514864077\work\code\common\src\sitkPimpleImageBase.hxx:201:
sitk::ERROR: vector dimension mismatch
```

Cheers!